### PR TITLE
Fix subprocess.communicate input type (to bytes)

### DIFF
--- a/patch-apk.py
+++ b/patch-apk.py
@@ -146,7 +146,7 @@ def runApkTool(params):
 		
 		#apktool.bat has a dirty hack that execute "pause", so we need a dirty hack to kill the pause command...
 		proc = subprocess.Popen(args, stdin=subprocess.PIPE, stdout=getStdout())
-		proc.communicate("\r\n")
+		proc.communicate(b"\r\n")
 		return proc
 	else:
 		args = ["apktool"]


### PR DESCRIPTION
Hi,

Good work!

I ran the script on Windows and noticed it fails in the runApkTool function, as the communicate function takes a bytes argument. Simple fix.

Cheers