### PR TITLE
Fix object-not-found from ADB on Linux

### DIFF
--- a/patch-apk.py
+++ b/patch-apk.py
@@ -219,8 +219,9 @@ def getAPKPathsForPackage(pkgname):
 	out = proc.stdout.decode("utf-8")
 	for line in out.split(os.linesep):
 		if line.startswith("package:"):
-			print("[+] APK path: " + line[8:])
-			paths.append(line[8:])
+			line = line[8:].strip()
+			print("[+] APK path: " + line)
+			paths.append(line)
 	print("")
 	return paths
 


### PR DESCRIPTION
Hi!
When running the script on Linux I encountered an error when it tries to pull the parts of a split APK.
It happens because at the end of the string there is a \r character that breaks the script.
I wrote a simple fix mimicking the one from your previous commit regarding packages.